### PR TITLE
Added support for comment command Cmd + '/'

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -90,6 +90,7 @@
         <gotoSymbolContributor implementation="com.nasmlanguage.NASMChooseByNameContributor"/>
         <spellchecker.support language="NASM" implementationClass="com.intellij.spellchecker.tokenizer.SpellcheckingStrategy"/>
         <annotator language="NASM" implementationClass="com.nasmlanguage.NASMAnnotator"/>
+        <lang.commenter language="NASM" implementationClass="com.nasmlanguage.NASMCommenter"/>
     </extensions>
 
     <actions>

--- a/src/com/nasmlanguage/NASMCommenter.java
+++ b/src/com/nasmlanguage/NASMCommenter.java
@@ -1,0 +1,56 @@
+/*++
+
+NASM Assembly Language Plugin
+Copyright (c) 2017-2018 Aidan Khoury. All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--*/
+
+package com.nasmlanguage;
+
+import com.intellij.lang.Commenter;
+import org.jetbrains.annotations.Nullable;
+
+public class NASMCommenter implements Commenter {
+    @Nullable
+    @Override
+    public String getLineCommentPrefix() {
+        return ";";
+    }
+
+    @Nullable
+    @Override
+    public String getBlockCommentPrefix() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getBlockCommentSuffix() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getCommentedBlockCommentPrefix() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getCommentedBlockCommentSuffix() {
+        return null;
+    }
+}


### PR DESCRIPTION
I really like using the cmd + '/' keyboard shortcut to quickly un/comment code blocks.