### PR TITLE
Add support for commas in directives

### DIFF
--- a/src/com/nasmlanguage/NASM.bnf
+++ b/src/com/nasmlanguage/NASM.bnf
@@ -339,8 +339,8 @@ private Mnemonic ::= (GENERAL_OP|SYSTEM_OP|VIRTUALIZATION_OP|X64_OP|FPU_OP|MMX_O
 MapOption ::= SQUARE_L ('map'|'MAP') (('all'|'ALL')|('brief'|'BRIEF')|('sections'|'SECTIONS')|('segments'|'SEGMENTS')|('symbols'|'SYMBOLS'))? MAP_FILE SQUARE_R
 
 Directive ::= (DirectiveDecl|DirectiveDeclBrackets|MapOption) CRLF*
-private DirectiveDecl ::= DIRECTIVE_OP DirectiveArg*
-private DirectiveDeclBrackets ::= SQUARE_L DirectiveDecl SQUARE_R
+private DirectiveDecl ::= DIRECTIVE_OP (DirectiveArg SEPARATOR?)*
+private DirectiveDeclBrackets ::= SQUARE_L DIRECTIVE_OP DirectiveArg* SQUARE_R
 DirectiveArg ::= ((MINUS|PLUS)? (MacroCall|NumericLiteral|Address|SegmentAddress|Identifier))
 
 // for eventual MASM support


### PR DESCRIPTION
It's annoying to see this great plugin highlighting commas in lines such as `extern printf, scanf` as errors.

From my quick experiments I conclude, that NASM allows commas (even trailing) in some directives, but not inside square brackets ([NASM docs](https://nasm.us/doc/nasmdoc6.html) call the latter 'primitive form'). I tried to update the BNF accordingly, but didn't test the changes, so something may go wrong.